### PR TITLE
Check if app id matches filename in detect_appid

### DIFF
--- a/merge/entrypoint.py
+++ b/merge/entrypoint.py
@@ -62,10 +62,17 @@ def detect_appid(dirname):
                             break
 
             if manifest:
+                manifest_file = os.path.basename(filename)
                 if "app-id" in manifest:
-                    ret = (os.path.basename(filename), manifest["app-id"])
+                    appid = manifest["app-id"]
                 elif 'id' in manifest:
-                    ret = (os.path.basename(filename), manifest["id"])
+                    appid = manifest["id"]
+                else:
+                    continue
+                if os.path.splitext(manifest_file)[0] != appid:
+                    print(f"Skipping {manifest_file}, does not match appid {appid}")
+                    continue
+                ret = (manifest_file, appid)
 
     return ret
 
@@ -124,10 +131,6 @@ def main():
         sys.exit(1)
 
     print(f"Detected {appid} as appid from {manifest_file}")
-
-    if os.path.splitext(manifest_file)[0] != appid:
-        print("Manifest filename does not match appid")
-        sys.exit(1)
 
     print("Creating new repo on Flathub")
     repo = org.create_repo(appid)


### PR DESCRIPTION
Filter out filenames not matching app IDs in them during manifest discovery, so that from multiple manifests only ones with matching app IDs are selected.
Expected behavior change: if repo contains single manifest and its filename doesn't match app id, `detect_appid()` will now return `None` instead that (invalid) manifest.
Should fix #9 