### PR TITLE
Skip cloning of archived repos

### DIFF
--- a/external-data-checker/gh-ls-org
+++ b/external-data-checker/gh-ls-org
@@ -20,4 +20,5 @@ if __name__ == "__main__":
     org = g.get_organization(args.organization)
 
     for repo in org.get_repos():
-        print(repo.html_url)
+        if not repo.archived:
+            print(repo.html_url)


### PR DESCRIPTION
external-data-checker can't push to archived repos anyway
so its just wasting time