### PR TITLE
external-data-checker: Allow repos to opt out

### DIFF
--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -8,9 +8,12 @@ fi
 detect_manifest() {
     repo=${1}
     
-    # ignore repos which opted out
-    if [[ -f $repo/.flathubbotignore ]]; then
-        return 1
+    # check if repo opted out
+    if [[ -f $repo/flathub.json ]]; then
+        jq -e '."disable-external-data-checker"' < $repo/flathub.json
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
     fi
 
     if [[ -f $repo/${repo}.yml ]]; then

--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -11,7 +11,7 @@ detect_manifest() {
     # check if repo opted out
     if [[ -f $repo/flathub.json ]]; then
         jq -e '."disable-external-data-checker"' < $repo/flathub.json
-        if [ $? -ne 0 ]; then
+        if [ $? -eq 0 ]; then
             return 1
         fi
     fi

--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -10,8 +10,8 @@ detect_manifest() {
     
     # check if repo opted out
     if [[ -f $repo/flathub.json ]]; then
-        jq -e '."disable-external-data-checker"' < $repo/flathub.json
-        if [ $? -eq 0 ]; then
+        jq -e '."disable-external-data-checker" | not' < $repo/flathub.json
+        if [ $? -ne 0 ]; then
             return 1
         fi
     fi

--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -7,6 +7,11 @@ fi
 
 detect_manifest() {
     repo=${1}
+    
+    # ignore repos which opted out
+    if [[ -f $repo/.flathubbotignore ]]; then
+        return 1
+    fi
 
     if [[ -f $repo/${repo}.yml ]]; then
         manifest=${repo}.yml

--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -10,8 +10,7 @@ detect_manifest() {
     
     # check if repo opted out
     if [[ -f $repo/flathub.json ]]; then
-        jq -e '."disable-external-data-checker" | not' < $repo/flathub.json
-        if [ $? -ne 0 ]; then
+        if ! jq -e '."disable-external-data-checker" | not' < $repo/flathub.json; then
             return 1
         fi
     fi


### PR DESCRIPTION
Allows repositories under the flathub organization to opt out of the organization f-e-d-c instance.

This way it's possible to create a custom f-e-d-c workflow which is useful for e.g. https://github.com/flathub/flatpak-external-data-checker/issues/252