### PR TITLE
Suppress `jq` output

### DIFF
--- a/flathub-external-data-checker/entrypoint.sh
+++ b/flathub-external-data-checker/entrypoint.sh
@@ -10,7 +10,7 @@ detect_manifest() {
     
     # check if repo opted out
     if [[ -f $repo/flathub.json ]]; then
-        if ! jq -e '."disable-external-data-checker" | not' < $repo/flathub.json; then
+        if ! jq -e '."disable-external-data-checker" | not' < $repo/flathub.json > /dev/null; then
             return 1
         fi
     fi


### PR DESCRIPTION
Should fix checking apps with `flathub.json` present.

Fixup for #16 