### PR TITLE
merge.yml: bump actions version

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,13 +11,13 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: merge
           file: merge/Dockerfile


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16).
- Bump the `docker/setup-buildx-action` to `v2`.
- Bump the `docker/login-action` to `v2`.
- Bump the `docker/build-push-action` to `v4`.