### PR TITLE
chore(ci): bump actions in merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,13 +11,13 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: merge
           file: merge/Dockerfile


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v3` (eol Node 16) to `v4` (Node 20).
- Bump `docker/setup-buildx-action` and `docker/login-action` to `v3` (Node 20).
- Bump `docker/build-push-action` from `v4` to `v5` (Node 20).